### PR TITLE
Construct collection with ClientInterface

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -67,11 +67,11 @@ final class Collection implements \Iterator, \Countable
     /**
      * Create a new collection
      *
-     * @param Client $client client connection to the API
+     * @param ClientInterface $client client connection to the API
      * @param string $resource name of API resource to request
      * @param array $filters key value pair array of search filters
      */
-    public function __construct(Client $client, $resource, array $filters = [])
+    public function __construct(ClientInterface $client, $resource, array $filters = [])
     {
         Util::throwIfNotType(['string' => [$resource]], true);
 


### PR DESCRIPTION
#### What does this PR do?
Allows the collection object to be constructed with a `ClientInterface` instead of the concrete `Client`
#### Checklist
- [ ] Pull request contains a clear definition of changes
- [ ] Tests (either unit, integration, or acceptance) written and passing
- [ ] Relevant documentation produced and/or updated
