### PR TITLE
Add send and startSend to ClientInterface

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -283,6 +283,36 @@ final class Client implements ClientInterface
     }
 
     /**
+     * Performs a request to the given URI and returns the response.
+     *
+     * @param string $method The HTTP method of the request to send.
+     * @param string $uri    A relative api URI to which the POST request will be made.
+     * @param array  $data   Array of data to be sent as the POST body.
+     *
+     * @return Response
+     */
+    public function send(string $method, string $uri, array $data = null) : Response
+    {
+        return $this->end($this->startSend($method, $uri, $data));
+    }
+
+    /**
+     * Starts a request to the given URI.
+     *
+     * @param string $method The HTTP method of the request to send.
+     * @param string $uri    A relative api URI to which the POST request will be made.
+     * @param array  $data   Array of data to be sent as the POST body.
+     *
+     * @return string opaque handle to be given to endDelete()
+     */
+    public function startSend(string $method, string $uri, array $data = null) : string
+    {
+        $url = "{$this->baseUrl}/{$uri}";
+        $json = $data !== null ? json_encode($data) : null;
+        return $this->start($url, $method, $json, ['Content-Type' => 'application/json']);
+    }
+
+    /**
      * Get response of start*() method
      *
      * @param string $handle opaque handle from start*()

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -92,6 +92,28 @@ interface ClientInterface
     public function delete(string $resource, string $id = null, array $data = null) : Response;
 
     /**
+     * Performs a request to the given URI and returns the response.
+     *
+     * @param string $method The HTTP method of the request to send.
+     * @param string $uri    A relative api URI to which the POST request will be made.
+     * @param array  $data   Array of data to be sent as the POST body.
+     *
+     * @return Response
+     */
+    public function send(string $method, string $uri, array $data = null) : Response;
+
+    /**
+     * Starts a request to the given URI.
+     *
+     * @param string $method The HTTP method of the request to send.
+     * @param string $uri    A relative api URI to which the POST request will be made.
+     * @param array  $data   Array of data to be sent as the POST body.
+     *
+     * @return string opaque handle to be given to endDelete()
+     */
+    public function startSend(string $method, string $uri, array $data = null) : string;
+
+    /**
      * Get response of start*() method
      *
      * @param string $handle opaque handle from start*()


### PR DESCRIPTION
#### What does this PR do?
Currently the client only supports calls to `/resource` or `/resource/123`.  This pull request adds the `send` and `startSend` method to allow calls to URIs such as `/resource/123/activate`

It also allows for methods other than GET, PUT, POST and DELETE

#### Checklist
- [ ] Pull request contains a clear definition of changes
- [ ] Tests (either unit, integration, or acceptance) written and passing
- [ ] Relevant documentation produced and/or updated
