### PR TITLE
Only set Content-Type header if request has body

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "require": {
         "php": "^7.0",
         "ext-curl": "*",
+        "ext-json": "*",
         "lib-curl": "~7.15",
         "guzzlehttp/guzzle": "^6.3",
         "psr/http-message": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "lib-curl": "~7.15",
+        "fig/http-message-util": "^1.1",
         "guzzlehttp/guzzle": "^6.3",
         "psr/http-message": "^1.0",
         "psr/simple-cache": "^1.0",

--- a/src/Client.php
+++ b/src/Client.php
@@ -271,7 +271,12 @@ final class Client implements ClientInterface
         }
 
         $json = $data !== null ? json_encode($data) : null;
-        return $this->start($url, 'DELETE', $json, ['Content-Type' => 'application/json']);
+        $headers = [];
+        if ($json !== null) {
+            $headers['Content-Type'] = 'application/json';
+        }
+
+        return $this->start($url, 'DELETE', $json, $headers);
     }
 
     /**
@@ -309,7 +314,12 @@ final class Client implements ClientInterface
     {
         $url = "{$this->baseUrl}/{$uri}";
         $json = $data !== null ? json_encode($data) : null;
-        return $this->start($url, $method, $json, ['Content-Type' => 'application/json']);
+        $headers = [];
+        if ($json !== null) {
+            $headers['Content-Type'] = 'application/json';
+        }
+
+        return $this->start($url, $method, $json, $headers);
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -2,7 +2,7 @@
 
 namespace TraderInteractive\Api;
 
-use ArrayObject;
+use Fig\Http\Message\StatusCodeInterface as StatusCodes;
 use SubjectivePHP\Psr\SimpleCache\InMemoryCache;
 use DominionEnterprises\Util\Arrays;
 use DominionEnterprises\Util\Http;
@@ -585,7 +585,6 @@ final class ClientTest extends TestCase
                 if ($request->getMethod() === 'DELETE'
                         && (string)$request->getUri() === 'baseUrl/v1/resource+name/the+id'
                         && $request->getHeaders() === [
-                            'Content-Type' => ['application/json'],
                             'Accept-Encoding' => ['gzip'],
                             'Authorization' => ['Bearer a token'],
                         ]
@@ -965,6 +964,37 @@ final class ClientTest extends TestCase
         $cache->clear();
         // no token requests should be made with second  request
         $this->assertSame(['a body'], $client->index('foos')->getResponse());
+    }
+
+    /**
+     * @test
+     * @covers ::send
+     * @covers ::startSend
+     */
+    public function startSendDoesNotAddContentTypeHeaderIfNoJsonIsGiven()
+    {
+        $adapter = new FakeAdapter(
+            function (RequestInterface $request) {
+                if (substr($request->getUri(), -5) === 'token') {
+                    return new Psr7Response(
+                        StatusCodes::STATUS_OK,
+                        ['Content-Type' => ['application/json']],
+                        json_encode(['access_token' => 'a token', 'expires_in' => 1])
+                    );
+                }
+
+                $this->assertSame('GET', $request->getMethod());
+                $this->assertSame('baseUrl/v1/feeds/123/transport', (string)$request->getUri());
+                $this->assertSame('', (string)$request->getBody());
+                $this->assertSame([], $request->getHeader('Content-Type'));
+                return new Psr7Response(StatusCodes::STATUS_OK);
+            }
+        );
+
+        $client = new Client($adapter, $this->getAuthentication(), 'baseUrl/v1');
+
+        $response = $client->send('GET', 'feeds/123/transport');
+        $this->assertSame(StatusCodes::STATUS_OK, $response->getHttpCode());
     }
 
     private function getAuthentication() : Authentication


### PR DESCRIPTION
#### What does this PR do?
This pull request updates the Client to only set the `Content-Type` header if the request has a body.
#### Checklist
- [ ] Pull request contains a clear definition of changes
- [ ] Tests (either unit, integration, or acceptance) written and passing
- [ ] Relevant documentation produced and/or updated
