### PR TITLE
Fix deprecation warning in PHP7.4

### DIFF
--- a/src/GuzzleAdapter.php
+++ b/src/GuzzleAdapter.php
@@ -92,7 +92,7 @@ final class GuzzleAdapter implements AdapterInterface
 
         $this->promises = [];
 
-        if (array_key_exists($endHandle, $this->exceptions)) {
+        if ($this->exceptions->offsetExists($endHandle)) {
             $exception = $this->exceptions[$endHandle];
             unset($this->exceptions[$endHandle]);
             throw $exception;


### PR DESCRIPTION
Since exceptions is an ArrayObject we cannot pass it to array_key_exists
https://www.php.net/manual/de/migration74.deprecated.php#migration74.deprecated.core.array-key-exists-objects

#### What does this PR do?

#### Checklist
- [ ] Pull request contains a clear definition of changes
- [ ] Tests (either unit, integration, or acceptance) written and passing
- [ ] Relevant documentation produced and/or updated
