### PR TITLE
Update to support guzzlehttp/promises v2.

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2']
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/src/GuzzleAdapter.php
+++ b/src/GuzzleAdapter.php
@@ -122,7 +122,7 @@ final class GuzzleAdapter implements AdapterInterface
         }
 
         $results = new ArrayObject();
-        Promise\each(
+        Promise\Each::of(
             $this->promises,
             function (ResponseInterface $response, $index) use ($results) {
                 $results[$index] = $response;


### PR DESCRIPTION
#### What does this PR do?
Removed deprecated use of `GuzzleHttp\Promise\each()` and replaced with `GuzzleHttp\Promise\Each::of()`

#### Checklist
- [ ] Pull request contains a clear definition of changes
- [ ] Tests (either unit, integration, or acceptance) written and passing
- [ ] Relevant documentation produced and/or updated
