### PR TITLE
Fix full URL issue in createApiGatewayClientCredentials

### DIFF
--- a/src/Authentication.php
+++ b/src/Authentication.php
@@ -141,18 +141,16 @@ final class Authentication
     /**
      * Creates a new instance of Authentication for Client Credentials grant type
      *
-     * @param string $clientId        The oauth client id
-     * @param string $clientSecret    The oauth client secret
-     * @param string $authUrl         The oauth auth url
-     * @param string $tokenResource   The access token resource of the API
+     * @param string $clientId     The oauth client id
+     * @param string $clientSecret The oauth client secret
+     * @param string $authUrl      The oauth auth url
      *
      * @return Authentication
      */
     public static function createApiGatewayClientCredentials(
         string $clientId,
         string $clientSecret,
-        string $authUrl,
-        string $tokenResource = 'token'
+        string $authUrl
     ) : Authentication {
         $getTokenRequestFunc = function (
             string $unusedBaseUrl,
@@ -160,13 +158,12 @@ final class Authentication
         ) use (
             $clientId,
             $clientSecret,
-            $authUrl,
-            $tokenResource
+            $authUrl
         ) {
             $data = ['client_id' => $clientId, 'client_secret' => $clientSecret, 'grant_type' => 'client_credentials'];
             return new Request(
                 'POST',
-                "{$authUrl}/oauth2/{$tokenResource}",
+                $authUrl,
                 ['Content-Type' => 'application/x-www-form-urlencoded'],
                 Http::buildQueryString($data)
             );

--- a/tests/AuthenticationTest.php
+++ b/tests/AuthenticationTest.php
@@ -186,7 +186,7 @@ final class AuthenticationTest extends TestCase
     {
         $auth = Authentication::createApiGatewayClientCredentials('id', 'secret', 'authUrl');
         $request = $auth->getTokenRequest('baseUrl');
-        $this->assertSame('authUrl/oauth2/token', (string)$request->getUri());
+        $this->assertSame('authUrl', (string)$request->getUri());
         $this->assertSame('POST', $request->getMethod());
         $this->assertSame(
             'client_id=id&client_secret=secret&grant_type=client_credentials',


### PR DESCRIPTION
#### What does this PR do?
This pull request updates the createApiGatewayClientCredentials method to simply use the authUrl parameter instead of authUrl plus the tokenResource parameter
#### Checklist
- [ ] Pull request contains a clear definition of changes
- [ ] Tests (either unit, integration, or acceptance) written and passing
- [ ] Relevant documentation produced and/or updated
