### PR TITLE
Wrap non-JSON responses in json error response

### DIFF
--- a/src/GuzzleAdapter.php
+++ b/src/GuzzleAdapter.php
@@ -3,6 +3,7 @@
 namespace TraderInteractive\Api;
 
 use ArrayObject;
+use GuzzleHttp\Psr7\Utils;
 use TraderInteractive\Util;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\ClientInterface as GuzzleClientInterface;
@@ -74,17 +75,25 @@ final class GuzzleAdapter implements AdapterInterface
         foreach ($results as $handle => $response) {
             try {
                 $contents = (string)$response->getBody();
-                if (trim($contents) !== '') {
-                    json_decode($contents, true);
-                    Util::ensure(
-                        JSON_ERROR_NONE,
-                        json_last_error(),
-                        '\UnexpectedValueException',
-                        [json_last_error_msg()]
-                    );
+                if (trim($contents) === '') {
+                    $this->responses[$handle] = $response;
+                    continue;
                 }
 
-                $this->responses[$handle] = $response;
+                json_decode($contents, true);
+                if (json_last_error() === JSON_ERROR_NONE) {
+                    $this->responses[$handle] = $response;
+                    continue;
+                }
+
+                $errorBody = [
+                    'error' => [
+                        'message' => 'Original API response did not contain valid JSON: ' . json_last_error_msg(),
+                        'originalResponse' => $contents,
+                    ],
+                ];
+
+                $this->responses[$handle] = $response->withBody(Utils::streamFor(json_encode($errorBody)));
             } catch (\Exception $e) {
                 $this->exceptions[$handle] = $e;
             }


### PR DESCRIPTION
#### What does this PR do?
This pull request updates the GuzzleAdapter to check the HTTP response for valid JSON. Before if the response was not valid json an exception was thrown. This change will intercept the non-JSON response and return an error formatted json response containing the original non-JSON response. This will maintain the original returned API status code as well
#### Checklist
- [ ] Pull request contains a clear definition of changes
- [ ] Tests (either unit, integration, or acceptance) written and passing
- [ ] Relevant documentation produced and/or updated
